### PR TITLE
Core options : fixed ARM64 JIT

### DIFF
--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -181,7 +181,7 @@ Option<int> cpu_core("ishiiruka_cpu_core", "CPU Core",
 #ifdef _M_X86
                                       {"JIT64", PowerPC::CPUCore::CORE_JIT64},
 #elif _M_ARM_64
-                                      {"JITARM64", PowerPC::CPUCore::JITARM64},
+                                      {"JITARM64", PowerPC::CPUCore::CORE_JITARM64},
 #endif
                                       {"Interpreter", PowerPC::CPUCore::CORE_INTERPRETER},
                                       {"Cached Interpreter", PowerPC::CPUCore::CORE_CACHEDINTERPRETER}});


### PR DESCRIPTION
The JIT fields in `CPUCore` were renamed from `JITXX` (Dolphin) to `CORE_JITXX` (Ishiiruka). This commit reflects the change in the core options for ARM64 JIT.